### PR TITLE
feat: support overlay components and plugins

### DIFF
--- a/packages/sanity-sveltekit/src/lib/types.ts
+++ b/packages/sanity-sveltekit/src/lib/types.ts
@@ -23,6 +23,11 @@ export interface VisualEditingProps extends Omit<VisualEditingOptions, 'history'
    * @deprecated The history adapter is already implemented
    */
   history?: never;
+  /**
+   * The refresh API allows smarter refresh logic than the default
+   * `location.reload()` behavior. You can call the refreshDefault argument to
+   * trigger the default refresh behavior so you don't have to reimplement it.
+   */
   refresh?: (
     payload: HistoryRefresh,
     refreshDefault: () => false | Promise<void>

--- a/packages/sanity-sveltekit/src/lib/visual-editing/VisualEditing.svelte
+++ b/packages/sanity-sveltekit/src/lib/visual-editing/VisualEditing.svelte
@@ -4,19 +4,14 @@
 
   const {
     children,
+    components,
     enabled = true,
+    plugins,
     refresh,
     zIndex
-  }: {
+  }: VisualEditingProps & {
     children?: Snippet;
     enabled?: boolean;
-    /**
-     * The refresh API allows smarter refresh logic than the default
-     * `location.reload()` behavior. You can call the refreshDefault argument to
-     * trigger the default refresh behavior so you don't have to reimplement it.
-     */
-    refresh?: VisualEditingProps['refresh'];
-    zIndex?: VisualEditingProps['zIndex'];
   } = $props();
 </script>
 
@@ -24,6 +19,6 @@
 
 {#if enabled}
   {#await import('./VisualEditingComponent.svelte') then { default: VisualEditing }}
-    <VisualEditing {zIndex} {refresh} />
+    <VisualEditing {components} {plugins} {refresh} {zIndex} />
   {/await}
 {/if}

--- a/packages/sanity-sveltekit/src/lib/visual-editing/VisualEditingComponent.svelte
+++ b/packages/sanity-sveltekit/src/lib/visual-editing/VisualEditingComponent.svelte
@@ -4,31 +4,14 @@
   import { onMount } from 'svelte';
   import type { VisualEditingProps } from '../types';
 
-  const {
-    refresh,
-    zIndex
-  }: {
-    refresh?: VisualEditingProps['refresh'];
-    zIndex?: VisualEditingProps['zIndex'];
-  } = $props();
+  const { components, plugins, refresh, zIndex }: VisualEditingProps = $props();
 
   let navigate: HistoryAdapterNavigate | undefined;
   let navigatingFromUpdate = false;
 
   onMount(() => {
     const disable = enableVisualEditing({
-      zIndex,
-      refresh: (payload) => {
-        function refreshDefault() {
-          if (payload.source === 'mutation' && payload.livePreviewEnabled) {
-            return false;
-          }
-          return new Promise<void>((resolve) => {
-            invalidateAll().then(resolve);
-          });
-        }
-        return refresh ? refresh(payload, refreshDefault) : refreshDefault();
-      },
+      components,
       history: {
         subscribe: (_navigate) => {
           navigate = _navigate;
@@ -49,7 +32,22 @@
             history.back();
           }
         }
-      }
+      },
+      plugins,
+      refresh: (payload) => {
+        function refreshDefault() {
+          if (payload.source === 'mutation' && payload.livePreviewEnabled) {
+            return false;
+          }
+
+          return new Promise<void>((resolve) => {
+            invalidateAll().then(resolve);
+          });
+        }
+
+        return refresh ? refresh(payload, refreshDefault) : refreshDefault();
+      },
+      zIndex
     });
     return () => disable();
   });


### PR DESCRIPTION
Adds support for the new `plugins` prop to the Visual Editing component, as well as the existing/legacy `components` prop, plus a bit of tidying.