### PR TITLE
feat: export client and groq helpers

### DIFF
--- a/apps/test/src/lib/sanity/client.ts
+++ b/apps/test/src/lib/sanity/client.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@sanity/client';
+import { createClient } from '@sanity/sveltekit';
 import {
   PUBLIC_SANITY_DATASET,
   PUBLIC_SANITY_PROJECT_ID,

--- a/apps/test/src/lib/sanity/queries.ts
+++ b/apps/test/src/lib/sanity/queries.ts
@@ -1,4 +1,4 @@
-import { defineQuery } from 'groq';
+import { defineQuery } from '@sanity/sveltekit';
 
 export const buildingsQuery = defineQuery(`*[_type == "building" && defined(slug.current)]{
   _id,

--- a/packages/sanity-sveltekit/package.json
+++ b/packages/sanity-sveltekit/package.json
@@ -59,6 +59,7 @@
     "@sanity/preview-url-secret": "^2.1.15",
     "@sanity/visual-editing": "^3.0.5",
     "fast-deep-equal": "^3.1.3",
+    "groq": "^3.99.0",
     "sanity": "^4.10.2"
   },
   "publishConfig": {

--- a/packages/sanity-sveltekit/src/lib/client/index.ts
+++ b/packages/sanity-sveltekit/src/lib/client/index.ts
@@ -1,0 +1,3 @@
+export type * from '@sanity/client';
+export { createClient } from '@sanity/client';
+export { stegaClean } from '@sanity/client/stega';

--- a/packages/sanity-sveltekit/src/lib/groq/index.ts
+++ b/packages/sanity-sveltekit/src/lib/groq/index.ts
@@ -1,0 +1,1 @@
+export { defineQuery, default as groq } from 'groq';

--- a/packages/sanity-sveltekit/src/lib/index.ts
+++ b/packages/sanity-sveltekit/src/lib/index.ts
@@ -1,6 +1,6 @@
 // Visual Editing
 export { default as VisualEditing } from './visual-editing/VisualEditing.svelte';
-export * from './createDataAttribute';
+export * from './visual-editing/createDataAttribute';
 
 // Live Content API
 export { default as LiveLoader } from './live/LiveLoader.svelte';
@@ -31,3 +31,9 @@ export type { SanityLocals, VisualEditingProps } from './types';
 
 // Studio
 export { default as SanityStudio } from './studio/SanityStudio.svelte';
+
+// Client
+export * from './client';
+
+// Groq
+export * from './groq';

--- a/packages/sanity-sveltekit/src/lib/visual-editing/createDataAttribute.ts
+++ b/packages/sanity-sveltekit/src/lib/visual-editing/createDataAttribute.ts
@@ -1,0 +1,5 @@
+export {
+  type CreateDataAttribute,
+  createDataAttribute,
+  type CreateDataAttributeProps
+} from '@sanity/visual-editing/create-data-attribute';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
+      groq:
+        specifier: ^3.99.0
+        version: 3.99.0
       sanity:
         specifier: ^4.10.2
         version: 4.10.2(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.1.12(@sanity/schema@4.10.2(@types/react@19.0.8)(debug@4.4.3))(@sanity/types@4.10.2(@types/react@19.0.8)))(@types/node@22.15.16)(@types/react@19.0.8)(immer@10.1.3)(jiti@2.6.0)(lightningcss@1.30.1)(postcss@8.5.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.9.2)(yaml@2.8.0)
@@ -3349,6 +3352,10 @@ packages:
 
   groq@3.88.1-typegen-experimental.0:
     resolution: {integrity: sha512-6TZD6H1y3P7zk0BQharjFa7BOivV9nFL6KKVZbRZRH0yOSSyu2xHglTO48b1/2mCEdYoBQpvE7rjCDUf6XmQYQ==}
+    engines: {node: '>=18'}
+
+  groq@3.99.0:
+    resolution: {integrity: sha512-ZwKAWzvVCw51yjmIf5484KgsAzZAlGTM4uy9lki4PjAYxcEME2Xf93d31LhHzgUAr2JI79H+cNKoRjDHdv1BXQ==}
     engines: {node: '>=18'}
 
   groq@4.10.2:
@@ -9216,6 +9223,8 @@ snapshots:
       - supports-color
 
   groq@3.88.1-typegen-experimental.0: {}
+
+  groq@3.99.0: {}
 
   groq@4.10.2: {}
 


### PR DESCRIPTION
Moves towards a single entry point for Sanity-related functionality. Instead of importing from multiple packages (`@sanity/client`, `groq`), developers can now import everything from `@sanity/sveltekit`. 

- Created new exports in the `sanity-sveltekit` package for Sanity client and GROQ functionality
- Added `groq` as a dependency to the `sanity-sveltekit` package
- Moved `createDataAttribute` to a dedicated visual-editing directory
- Created new modules for client and GROQ functionality with proper re-exports
- Updated imports in the test app to use the new unified package instead of direct dependencies