### PR TITLE
feat!: rename DraftPerspective to PreviewPerspective

### DIFF
--- a/packages/sanity-sveltekit/src/lib/context/perspective.ts
+++ b/packages/sanity-sveltekit/src/lib/context/perspective.ts
@@ -9,18 +9,18 @@ const perspectiveContextKey = Symbol('perspective');
 /**
  * @public
  */
-export type DraftPerspective = 'checking' | 'unknown' | ClientPerspective;
+export type PreviewPerspective = 'checking' | 'unknown' | ClientPerspective;
 
 /**
  * @public
  */
-export function setPerspective(perspective: { value: DraftPerspective }) {
+export function setPerspective(perspective: { value: PreviewPerspective }) {
   setContext(perspectiveContextKey, perspective);
 }
 
 /**
  * @public
  */
-export function getPerspective(): { value: DraftPerspective } {
+export function getPerspective(): { value: PreviewPerspective } {
   return getContext(perspectiveContextKey);
 }

--- a/packages/sanity-sveltekit/src/lib/index.ts
+++ b/packages/sanity-sveltekit/src/lib/index.ts
@@ -14,7 +14,7 @@ export { loadQuery, setServerClient, useLiveMode, useQuery } from './query/store
 
 // Context
 export { getEnvironment, setEnvironment, type DraftEnvironment } from './context/environment';
-export { getPerspective, setPerspective, type DraftPerspective } from './context/perspective';
+export { getPerspective, setPerspective, type PreviewPerspective } from './context/perspective';
 export { getIsPreviewing, setIsPreviewing } from './context/previewing';
 export { getLoader, setLoader, type LoaderType } from './context/loader';
 

--- a/packages/sanity-sveltekit/src/lib/live/LiveLoader.svelte
+++ b/packages/sanity-sveltekit/src/lib/live/LiveLoader.svelte
@@ -14,7 +14,7 @@
   import { invalidate, invalidateAll } from '$app/navigation';
   import { onMount, type Snippet } from 'svelte';
   import { setEnvironment, type DraftEnvironment } from '../context/environment';
-  import { setPerspective, type DraftPerspective } from '../context/perspective';
+  import { setPerspective, type PreviewPerspective } from '../context/perspective';
   import { isCorsOriginError } from '../util';
   import ComlinkPerspective from './ComlinkPerspective.svelte';
   import RefreshOnFocus from './RefreshOnFocus.svelte';
@@ -125,7 +125,7 @@
   /**
    * Set the perspective based on the preview state
    */
-  const perspective = $state<{ value: DraftPerspective }>({
+  const perspective = $state<{ value: PreviewPerspective }>({
     value: 'checking'
   });
   setPerspective(perspective);

--- a/packages/sanity-sveltekit/src/lib/live/handleLiveLoader.ts
+++ b/packages/sanity-sveltekit/src/lib/live/handleLiveLoader.ts
@@ -15,13 +15,12 @@ export interface HandleLiveLoaderConfig {
    */
   client?: SanityClient;
   /**
-   * Optional. If provided then the token needs to have permissions to query documents with `drafts.` prefixes in order for `perspective: 'drafts'` to work.
+   * Optional. If provided, the token needs to have permissions to query documents with `drafts.` prefixes in order for `perspective: 'drafts'` to work.
    * This token is not shared with the browser.
    */
   serverToken?: string;
   /**
-   * Optional. This token is shared with the browser, and should only have access to query published documents.
-   * It is used to setup a `Live Draft Content` EventSource connection, and enables live previewing drafts stand-alone, outside of Presentation Tool.
+   * Optional. This token is shared with the browser when preview mode is enabled. It is used to setup a `Live Draft Content` EventSource connection, and enables live previewing drafts stand-alone, outside of Presentation Tool.
    */
   browserToken?: string;
   /**
@@ -35,7 +34,7 @@ export interface HandleLiveLoaderConfig {
     revalidate?: number | false;
   };
   /**
-   * Optional. Include stega encoding when draft mode is enabled.
+   * Optional. Include stega encoding when preview mode is enabled.
    *  @defaultValue `true`
    */
   stega?: boolean;

--- a/packages/sanity-sveltekit/src/lib/query/QueryLoader.svelte
+++ b/packages/sanity-sveltekit/src/lib/query/QueryLoader.svelte
@@ -8,7 +8,11 @@
     children,
     client,
     enabled = true
-  }: { children?: Snippet; client: SanityClient; enabled?: boolean } = $props();
+  }: {
+    children?: Snippet;
+    client: SanityClient;
+    enabled?: boolean;
+  } = $props();
 
   const loader = $state<{ value: LoaderType }>({
     value: undefined


### PR DESCRIPTION
- Renamed `DraftPerspective` type to `PreviewPerspective`
- Improved documentation comments to use consistent "preview" terminology instead of "draft"
- Clarified the purpose of `browserToken` in the `handleLiveLoader.ts` configuration