### PR TITLE
chore: fix release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,12 +13,12 @@ on:
         type: boolean
 
 permissions:
-  contents: read # for checkout
+  contents: write # for release-please to update manifest files
 
 jobs:
   release-please:
     permissions:
-      contents: read # for checkout
+      contents: write # for release-please to update manifest files
       id-token: write # to enable use of OIDC for npm provenance
     runs-on: ubuntu-latest
     env:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/sanity-sveltekit":"1.0.0"}
+{"packages/sanity-sveltekit":"1.0.1"}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "last-release-sha": "8ab1f98bf015c590f23612e06251c68e5cac0aef",
+  "last-release-sha": "0f61a681c0e1ba39344c1c2a94a2cc772e53bfb8",
   "plugins": ["node-workspace"],
   "packages": {
     "packages/sanity-sveltekit": {


### PR DESCRIPTION
- Modified `.github/workflows/release-please.yml` to grant write permissions to the `contents` scope, allowing release-please to update manifest files
- Updated `.release-please-manifest.json` to bump the `@sanity/sveltekit` version from `1.0.0` to `1.0.1`
- Updated `release-please-config.json` with a new `last-release-sha` value pointing to the latest release commit