### PR TITLE
chore: use packagejson prettier plugin

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
   "singleQuote": true,
   "trailingComma": "none",
   "printWidth": 100,
-  "plugins": ["prettier-plugin-svelte"],
+  "plugins": ["prettier-plugin-packagejson", "prettier-plugin-svelte"],
   "overrides": [
     {
       "files": "*.svelte",


### PR DESCRIPTION
Updated the `.prettierrc` file to include `prettier-plugin-packagejson` in the plugins array, alongside the existing `prettier-plugin-svelte`.