### PR TITLE
fix: read perspective from previewEnabled per-request, not client config at init

### DIFF
--- a/packages/sanity-sveltekit/src/lib/query/handleQueryLoader.ts
+++ b/packages/sanity-sveltekit/src/lib/query/handleQueryLoader.ts
@@ -65,10 +65,13 @@ export const handleQueryLoader = (config?: HandleQueryLoaderConfig): Handle => {
   if (!client) throw new Error('No client instance provided to handleLoadQuery');
 
   const loadQuery = config?.loadQuery || defaultLoadQuery;
-  const { perspective, useCdn } = client.config();
 
   return async ({ event, resolve }) => {
-    // Set `sanity` properties on the `event.locals` object
+    // handlePreviewMode uses 'drafts', but loadQuery needs 'previewDrafts' (published + drafts).
+    const previewEnabled = event.locals.sanity?.previewEnabled ?? false;
+    const perspective: ClientPerspective = previewEnabled ? 'previewDrafts' : 'published';
+    const useCdn = !previewEnabled;
+
     setLocals({
       event,
       loadQuery,


### PR DESCRIPTION
Fixes #212

`handleQueryLoader` captured `perspective`/`useCdn` from `client.config()` at hook init time. Since the default client has no explicit perspective, `options.perspective` was always `undefined` (resolved to `'published'` by the store's `loadQuery`). This meant server-side `sanity.loadQuery()` always ran with `'published'` perspective regardless of preview state, causing draft detail pages to 404 in Presentation mode.

## Changes

Moved perspective/useCdn resolution from init-time (once, in the `handleQueryLoader` closure) to **per-request** inside the request handler. Reads `previewEnabled` from `event.locals.sanity` (set by `handlePreviewMode`) and uses `'previewDrafts'` when preview is active.

## Why `'previewDrafts'` and not read from `event.locals.sanity.client`?

`handlePreviewMode.setLocals` creates a client with `perspective: 'drafts'` (drafts-only). Reading from that client config would pass `'drafts'` to `loadQuery`, which only returns draft documents — breaking navigation to published posts during preview. `'previewDrafts'` returns both published and drafts, which is what the listing and detail pages need.

`handleLiveLoader` already follows the same pattern (reads `previewEnabled` per-request), but uses the perspective cookie from the Presentation tool. `handleQueryLoader` doesn't have access to that cookie, so it determines perspective from the `previewEnabled` boolean directly.